### PR TITLE
export csv done✅

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -289,7 +289,9 @@
 			<h1 class="instrument-serif-regular">CanYouRegMyEx</h1>
 		</div>
 		<div class="flex gap-10">
-			<p class="hover:text-[#325FEC]">Download CSV</p>
+			<p class="hover:text-[#325FEC]">
+				<a href="{BASE_URL}/export_file/get_csv" download="ConanEpisodes.csv"> Download CSV </a>
+			</p>
 			<p class="hover:text-[#325FEC]"><a href="https://github.com/CanYouRegMyEx">Source Code</a></p>
 			<p class="hover:text-[#325FEC]"><a href="#">Youtube</a></p>
 			<p class="hover:text-[#325FEC]">


### PR DESCRIPTION
This pull request updates the CSV download functionality on the main page to provide a direct download link. Instead of a plain text label, users now get an actual clickable link that downloads the CSV file when clicked.

User interface improvement:

* Changed the "Download CSV" text to a direct download link, using an anchor tag that points to `{BASE_URL}/export_file/get_csv` and sets the filename to `ConanEpisodes.csv`.